### PR TITLE
[UIKit] MInput fitted to design

### DIFF
--- a/src/atoms/MCaption/MCaption.module.css
+++ b/src/atoms/MCaption/MCaption.module.css
@@ -5,4 +5,18 @@
   align-items: center;
   justify-content: flex-start;
   gap: var(--input-field-whiteSpace-label-gap, 8px);
+  color: var(--input-field-enabled-font-color, #747e97);
+  font-family: var(--font-family-secondary, Roboto);
+  font-size: var(--font-size-l, 16px);
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+}
+
+.caption.valid {
+  color: var(--input-field-valid-font-color, #747e97);
+}
+
+.caption.invalid {
+  color: var(--input-field-invalid-assistive-font-color, #dc2020);
 }

--- a/src/atoms/MCaption/MCaption.tsx
+++ b/src/atoms/MCaption/MCaption.tsx
@@ -2,16 +2,22 @@ import React from 'react';
 import clsx from 'clsx';
 import MText, { TextProps } from '../MText/MText';
 import styles from './MCaption.module.css';
+import { TComponentStatus } from 'types/TComponentStatus';
 
-type CaptionProps = Omit<TextProps, 'size'>;
+type CaptionProps = Omit<TextProps, 'size'> & Partial<TComponentStatus>;
 
 export const MCaption = ({
+  status = 'regular',
   children,
   className,
   ...restProps
 }: CaptionProps) => {
   return (
-    <MText size="m" className={clsx(styles.caption, className)} {...restProps}>
+    <MText
+      size="m"
+      className={clsx(styles.caption, styles[status], className)}
+      {...restProps}
+    >
       {children}
     </MText>
   );

--- a/src/atoms/MFieldDescription/MFieldDescription.module.css
+++ b/src/atoms/MFieldDescription/MFieldDescription.module.css
@@ -1,11 +1,16 @@
 .fieldDescription {
-  color: var(--input-text-field-enabled-assistive-font-color);
+  color: var(--input-field-enabled-font-color, #747e97);
+  font-family: var(--font-family-secondary, Roboto);
+  font-size: var(--font-size-m, 14px);
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
 }
 
 .fieldDescription.valid {
-  color: var(--input-text-field-valid-assistive-font-color);
+  color: var(--input-field-valid-font-color, #747e97);
 }
 
 .fieldDescription.invalid {
-  color: var(--input-text-field-invalid-assistive-font-color, #dc2020);
+  color: var(--input-field-invalid-assistive-font-color, #dc2020);
 }

--- a/src/atoms/MInput/MInput.module.css
+++ b/src/atoms/MInput/MInput.module.css
@@ -3,123 +3,151 @@
 }
 
 .inputContainer {
+  transition: border 0.2s ease-in-out;
+}
+
+.inputContainer > div,
+.inputContainer > input {
+  transition: color 0.2s ease-in-out;
+}
+
+.inputContainer {
   width: 100%;
-
   box-sizing: border-box;
-
   padding: var(--input-field-whiteSpace-field-padding-vertical, 12px)
     var(--input-field-whiteSpace-field-padding-horizontal, 16px);
-  border-radius: var(--input-field-borderRadius-default, 8px);
-  transition: all 0.2s ease-in-out;
+  border-radius: var(--input-field-borderRadius-default, 16px);
 }
 
 .input {
-  border: 0 none;
+  border: none;
   flex: 1;
-  outline: none;
-  font-size: var(--typography-font-size-m, 14px);
+  font-family: var(--font-family-secondary, Roboto);
+  font-size: var(--font-size-l, 16px);
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
 }
 
 /** States */
 
 /* enabled */
 .inputWrapper.regular .inputContainer {
-  border: 1px solid var(--input-text-field-enabled-border-color, #d9d9d9);
-  background: var(
-    --input-text-field-enabled-background-color,
-    rgba(255, 255, 255, 0)
-  );
-  color: var(--input-text-field-enabled-font-color, #8c8c8c);
+  border: 1px solid var(--input-field-enabled-border-color, #0000001e);
+  background: var(--input-field-enabled-background-color, #fff);
+  color: var(--input-field-enabled-font-before-after, #babecb);
 }
 
 .inputWrapper.regular .inputContainer input {
-  color: var(--input-text-field-enabled-font-color, #8c8c8c);
+  color: var(--input-field-enabled-font-color, #747e97);
 }
 
 /* valid */
 .inputWrapper.valid .inputContainer {
-  border: 1px solid var(--input-text-field-valid-border-color, #479900);
-  background: var(
-    --input-text-field-valid-background-color,
-    rgba(255, 255, 255, 0)
-  );
-  color: var(--input-text-field-valid-font-color, #000);
+  border: 1px solid var(--input-field-valid-border-color, #479900);
+  background: var(--input-field-valid-background-color, transparent);
+  color: var(--input-field-valid-font-before-after, #babecb);
 }
 
 .inputWrapper.valid .inputContainer input {
-  color: var(--input-text-field-valid-font-color, #000);
+  color: var(--input-field-valid-font-color, #747e97);
 }
 
 /* invalid */
 .inputWrapper.invalid .inputContainer {
-  border: 1px solid var(--input-text-field-invalid-border-color, #dc2020);
-  background: var(
-    --input-text-field-invalid-background-color,
-    rgba(255, 255, 255, 0)
-  );
-  color: var(--input-text-field-invalid-font-color, #dc2020);
+  border: 1px solid var(--input-field-invalid-border-color, #dc2020);
+  background: var(--input-field-invalid-background-color, transparent);
+  color: var(--input-field-invalid-font-before-after, #dc2020);
 }
 
 .inputWrapper.invalid .inputContainer input {
-  color: var(--input-text-field-invalid-font-color, #dc2020);
+  color: var(--input-field-invalid-font-color, #dc2020);
 }
 
 /* hover */
-.inputWrapper:hover .inputContainer {
-  border: 1px solid var(--input-text-field-hover-border-color, #d9d9d9);
+.inputWrapper:not(.invalid):hover .inputContainer {
   background: var(
-    --input-text-field-hover-background-color,
+    --input-field-hover-background-color,
     rgba(255, 255, 255, 0.05)
-  );
-  color: var(--input-text-field-hover-font-color, #8c8c8c);
+  ); /* this property was here initially, but I can't see any visual effect */
+  color: var(--input-field-hover-font-color, #747e97);
 }
 
-.inputWrapper:hover .inputContainer input {
-  color: var(--input-text-field-hover-font-color, #8c8c8c);
+.inputWrapper:not(.invalid):hover .inputContainer input {
+  color: var(--input-field-hover-font-color, #747e97);
 }
 
 /* focus */
-.inputWrapper:has(.input:focus) .inputContainer {
-  border: 1px solid var(--input-text-field-focus-border-color, #2994ff);
+.inputWrapper:not(.invalid):has(.input:focus) .inputContainer {
   background: var(
-    --input-text-field-focus-background-color,
-    rgba(255, 255, 255, 0)
-  );
-  color: var(--input-text-field-focus-font-color, #000);
+    --input-field-focus-background-color,
+    transparent
+  ); /* this property was here initially, but I can't see any visual effect */
+  color: var(--input-field-focus-font-color-before-after, #747e97);
 }
 
 .inputWrapper:has(.input:focus) .inputContainer input {
-  color: var(--input-text-field-focus-font-color, #000);
+  color: var(--input-field-focus-font-color, #000);
 }
 
 /* active */
-.inputWrapper:has(.input:active) .inputContainer {
-  color: var(--input-text-field-active-font-color, #8c8c8c);
-  border: 1px solid #8c8c8c;
+.inputWrapper:not(.invalid):has(.input:active) .inputContainer {
+  color: var(--input-field-active-font-color, #747e97);
   background: var(
-    --input-text-field-active-background-color,
+    --input-field-active-background-color,
     rgba(255, 255, 255, 0)
-  );
+  ); /* this property was here initially, but I can't see any visual effect */
 }
 
 .inputWrapper:has(.input:active) .inputContainer input {
-  color: var(--input-text-field-active-font-color, #8c8c8c);
+  color: var(--input-field-active-font-color, #747e97);
 }
 
 /* disabled */
 .inputWrapper:has(.input:disabled) .inputContainer {
-  color: var(--input-text-field-disabled-font-color, #bfbfbf);
-  border: 1px solid var(--input-text-field-disabled-border-color, #bfbfbf);
-  background: var(
-    --input-text-field-disabled-background-color,
-    rgba(0, 0, 0, 0.1)
-  );
+  color: var(--input-field-disabled-font-color, #babecb);
+  border: 1px solid var(--input-field-disabled-border-color, #0000001e);
+  background: var(--input-field-disabled-background-color, #f4f5f7);
 }
 
 .inputWrapper:has(.input:disabled) .inputContainer input {
-  color: var(--input-text-field-disabled-font-color, #bfbfbf);
+  color: var(--input-field-disabled-font-color, #babecb);
+  background: var(--input-field-disabled-background-color, #f4f5f7);
+}
+
+.inputWrapper:has(.input:disabled):hover .inputContainer,
+.inputWrapper:has(.input:disabled):focus .inputContainer,
+.inputWrapper:has(.input:disabled):active .inputContainer {
+  color: var(--input-field-disabled-font-color, #babecb);
+  background: var(--input-field-disabled-background-color, #f4f5f7);
 }
 
 .inputWrapper.invalid:has(.input:disabled) .inputContainer {
-  border: 1px solid #dc2020;
+  border: 1px solid var(--input-field-invalid-font-color, #dc2020);
+  color: var(--input-field-invalid-font-color, #dc2020);
+}
+
+.input:focus-visible {
+  outline: none;
+}
+
+.input::placeholder {
+  color: var(--input-field-enabled-placeholder, #babecb);
+  transition: all 0.2s ease-in-out; /* color|opacity transitions for placeholders are not supported in Firefox */
+}
+
+.inputWrapper.invalid .inputContainer input::placeholder {
+  color: var(--input-field-invalid-font-color, #dc2020);
+}
+
+.inputWrapper:not(.invalid):not(:has(input:disabled)):hover
+  .inputContainer
+  input::placeholder {
+  color: var(--input-field-hover-placeholder, #747e97);
+}
+
+.inputWrapper:not(.invalid):not(:has(input:disabled)):has(.input:focus)
+  .inputContainer
+  input::placeholder {
+  color: var(--input-field-hover-placeholder, #747e97);
 }

--- a/src/atoms/MInput/MInput.tsx
+++ b/src/atoms/MInput/MInput.tsx
@@ -59,8 +59,12 @@ export const MInput = ({
         justify="space-between"
         className={clsx(styles.inputHeading, headingClassName)}
       >
-        {label && <MLabel htmlFor={fieldId}>{label}</MLabel>}
-        {caption && <MCaption>{caption}</MCaption>}
+        {label && (
+          <MLabel htmlFor={fieldId} status={status}>
+            {label}
+          </MLabel>
+        )}
+        {caption && <MCaption status={status}>{caption}</MCaption>}
       </MFlex>
       <MFlex className={clsx(styles.inputContainer, containerClassName)}>
         {before && (

--- a/src/atoms/MLabel/MLabel.module.css
+++ b/src/atoms/MLabel/MLabel.module.css
@@ -1,4 +1,17 @@
 /** TODO: use variables */
 .label {
-  color: var(--input-text-field-disabled-label-font-color, #000);
+  color: var(--input-field-enabled-font-color, #747e97);
+  font-family: var(--font-family-secondary, Roboto);
+  font-size: var(--font-size-l, 16px);
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+}
+
+.label.valid {
+  color: var(--input-field-valid-font-color, #747e97);
+}
+
+.label.invalid {
+  color: var(--input-field-invalid-assistive-font-color, #dc2020);
 }

--- a/src/atoms/MLabel/MLabel.tsx
+++ b/src/atoms/MLabel/MLabel.tsx
@@ -2,15 +2,25 @@ import React from 'react';
 import clsx from 'clsx';
 import MText from '../MText/MText';
 import styles from './MLabel.module.css';
+import { TComponentStatus } from 'types/TComponentStatus';
 
 type LabelProps = React.DetailedHTMLProps<
   React.LabelHTMLAttributes<HTMLLabelElement>,
   HTMLLabelElement
->;
+> &
+  Partial<TComponentStatus>;
 
-export const MLabel = ({ children, className, ...restProps }: LabelProps) => {
+export const MLabel = ({
+  children,
+  className,
+  status = 'regular',
+  ...restProps
+}: LabelProps) => {
   return (
-    <label className={clsx(styles.label, className)} {...restProps}>
+    <label
+      className={clsx(styles.label, styles[status], className)}
+      {...restProps}
+    >
       <MText as="div" size="l">
         {children}
       </MText>

--- a/src/styles/brand/locationtips.css
+++ b/src/styles/brand/locationtips.css
@@ -69,7 +69,7 @@
   --borderRadius-general-_5x: 0.13rem;
   --borderRadius-general-1x: 0.25rem;
   --borderRadius-general-1_5x: 0.38rem;
-  --borderRadius-general-2x: 1rem;
+  --borderRadius-general-2x: 0.5rem;
   --borderRadius-general-3x: 0.75rem;
   --borderRadius-general-4x: 1rem;
   --borderRadius-general-6x: 1.5rem;

--- a/src/styles/brand/locationtips.css
+++ b/src/styles/brand/locationtips.css
@@ -1,6 +1,7 @@
 :root[data-brand='locationtips'] {
   /* typo */
   --font-family: Poppins, sans-serif;
+  --font-family-secondary: Roboto, sans-serif;
   --font-size-s: 0.875rem;
   --font-size-m: 0.875rem;
   --font-size-l: 1rem;
@@ -51,6 +52,7 @@
   --palette-neutral-120: rgba(20, 20, 20, 1);
   --palette-neutral-130-black: rgba(0, 0, 0, 1);
 
+  --input-regular-border: rgba(0, 0, 0, 0.12);
   /* sizes */
   --whiteSpace-general-_25x: 0.13rem;
   --whiteSpace-general-_5x: 0.25rem;

--- a/src/styles/platform/android.css
+++ b/src/styles/platform/android.css
@@ -7,7 +7,7 @@
     --whiteSpace-general-1_5x
   );
   --button-primary-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
-  --button-primary-medium-borderRadius-default: var(--borderRadius-general-2x);
+  --button-primary-medium-borderRadius-default: var(--borderRadius-general-4x);
   --button-secondary-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );
@@ -16,7 +16,7 @@
   );
   --button-secondary-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
   --button-secondary-medium-borderRadius-default: var(
-    --borderRadius-general-2x
+    --borderRadius-general-4x
   );
   --button-outlined-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
@@ -25,9 +25,9 @@
     --whiteSpace-general-1_5x
   );
   --button-outlined-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
-  --button-outlined-medium-borderRadius-default: var(--borderRadius-general-2x);
+  --button-outlined-medium-borderRadius-default: var(--borderRadius-general-4x);
   --button-transparent-medium-borderRadius-default: var(
-    --borderRadius-general-2x
+    --borderRadius-general-4x
   );
   --button-transparent-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
   --input-field-whiteSpace-field-padding-horizontal: var(
@@ -40,5 +40,5 @@
   --input-field-whiteSpace-label-gap: var(--whiteSpace-general-1x);
   --input-field-whiteSpace-caption-gap: var(--whiteSpace-general-1x);
   --input-field-whiteSpace-assistive-gap: var(--whiteSpace-general-1x);
-  --input-field-borderRadius-default: var(--borderRadius-general-2x);
+  --input-field-borderRadius-default: var(--borderRadius-general-4x);
 }

--- a/src/styles/platform/ios.css
+++ b/src/styles/platform/ios.css
@@ -7,7 +7,7 @@
     --whiteSpace-general-1_5x
   );
   --button-primary-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
-  --button-primary-medium-borderRadius-default: var(--borderRadius-general-2x);
+  --button-primary-medium-borderRadius-default: var(--borderRadius-general-4x);
   --button-secondary-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );
@@ -16,7 +16,7 @@
   );
   --button-secondary-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
   --button-secondary-medium-borderRadius-default: var(
-    --borderRadius-general-2x
+    --borderRadius-general-4x
   );
   --button-outlined-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
@@ -25,9 +25,9 @@
     --whiteSpace-general-1_5x
   );
   --button-outlined-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
-  --button-outlined-medium-borderRadius-default: var(--borderRadius-general-2x);
+  --button-outlined-medium-borderRadius-default: var(--borderRadius-general-4x);
   --button-transparent-medium-borderRadius-default: var(
-    --borderRadius-general-2x
+    --borderRadius-general-4x
   );
   --button-transparent-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
   --input-field-whiteSpace-field-padding-horizontal: var(
@@ -40,5 +40,5 @@
   --input-field-whiteSpace-label-gap: var(--whiteSpace-general-1x);
   --input-field-whiteSpace-caption-gap: var(--whiteSpace-general-1x);
   --input-field-whiteSpace-assistive-gap: var(--whiteSpace-general-1x);
-  --input-field-borderRadius-default: var(--borderRadius-general-2x);
+  --input-field-borderRadius-default: var(--borderRadius-general-4x);
 }

--- a/src/styles/platform/webdesktop.css
+++ b/src/styles/platform/webdesktop.css
@@ -7,7 +7,7 @@
     --whiteSpace-general-1_5x
   );
   --button-primary-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
-  --button-primary-medium-borderRadius-default: var(--borderRadius-general-2x);
+  --button-primary-medium-borderRadius-default: var(--borderRadius-general-4x);
   --button-secondary-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );
@@ -16,7 +16,7 @@
   );
   --button-secondary-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
   --button-secondary-medium-borderRadius-default: var(
-    --borderRadius-general-2x
+    --borderRadius-general-4x
   );
   --button-outlined-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
@@ -25,9 +25,9 @@
     --whiteSpace-general-1_5x
   );
   --button-outlined-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
-  --button-outlined-medium-borderRadius-default: var(--borderRadius-general-2x);
+  --button-outlined-medium-borderRadius-default: var(--borderRadius-general-4x);
   --button-transparent-medium-borderRadius-default: var(
-    --borderRadius-general-2x
+    --borderRadius-general-4x
   );
   --button-transparent-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
   --input-field-whiteSpace-field-padding-horizontal: var(
@@ -40,5 +40,5 @@
   --input-field-whiteSpace-label-gap: var(--whiteSpace-general-1x);
   --input-field-whiteSpace-caption-gap: var(--whiteSpace-general-1x);
   --input-field-whiteSpace-assistive-gap: var(--whiteSpace-general-1x);
-  --input-field-borderRadius-default: var(--borderRadius-general-2x);
+  --input-field-borderRadius-default: var(--borderRadius-general-4x);
 }

--- a/src/styles/platform/webmobile.css
+++ b/src/styles/platform/webmobile.css
@@ -7,7 +7,7 @@
     --whiteSpace-general-1_5x
   );
   --button-primary-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
-  --button-primary-medium-borderRadius-default: var(--borderRadius-general-2x);
+  --button-primary-medium-borderRadius-default: var(--borderRadius-general-4x);
   --button-secondary-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );
@@ -16,7 +16,7 @@
   );
   --button-secondary-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
   --button-secondary-medium-borderRadius-default: var(
-    --borderRadius-general-2x
+    --borderRadius-general-4x
   );
   --button-outlined-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
@@ -25,9 +25,9 @@
     --whiteSpace-general-1_5x
   );
   --button-outlined-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
-  --button-outlined-medium-borderRadius-default: var(--borderRadius-general-2x);
+  --button-outlined-medium-borderRadius-default: var(--borderRadius-general-4x);
   --button-transparent-medium-borderRadius-default: var(
-    --borderRadius-general-2x
+    --borderRadius-general-4x
   );
   --button-transparent-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
   --input-field-whiteSpace-field-padding-horizontal: var(
@@ -40,5 +40,5 @@
   --input-field-whiteSpace-label-gap: var(--whiteSpace-general-1x);
   --input-field-whiteSpace-caption-gap: var(--whiteSpace-general-1x);
   --input-field-whiteSpace-assistive-gap: var(--whiteSpace-general-1x);
-  --input-field-borderRadius-default: var(--borderRadius-general-2x);
+  --input-field-borderRadius-default: var(--borderRadius-general-4x);
 }

--- a/src/styles/platform/webtablet.css
+++ b/src/styles/platform/webtablet.css
@@ -7,7 +7,7 @@
     --whiteSpace-general-1_5x
   );
   --button-primary-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
-  --button-primary-medium-borderRadius-default: var(--borderRadius-general-2x);
+  --button-primary-medium-borderRadius-default: var(--borderRadius-general-4x);
   --button-secondary-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );
@@ -16,7 +16,7 @@
   );
   --button-secondary-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
   --button-secondary-medium-borderRadius-default: var(
-    --borderRadius-general-2x
+    --borderRadius-general-4x
   );
   --button-outlined-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
@@ -25,9 +25,9 @@
     --whiteSpace-general-1_5x
   );
   --button-outlined-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
-  --button-outlined-medium-borderRadius-default: var(--borderRadius-general-2x);
+  --button-outlined-medium-borderRadius-default: var(--borderRadius-general-4x);
   --button-transparent-medium-borderRadius-default: var(
-    --borderRadius-general-2x
+    --borderRadius-general-4x
   );
   --button-transparent-medium-whiteSpace-gap: var(--whiteSpace-general-1x);
   --input-field-whiteSpace-field-padding-horizontal: var(
@@ -40,5 +40,5 @@
   --input-field-whiteSpace-label-gap: var(--whiteSpace-general-1x);
   --input-field-whiteSpace-caption-gap: var(--whiteSpace-general-1x);
   --input-field-whiteSpace-assistive-gap: var(--whiteSpace-general-1x);
-  --input-field-borderRadius-default: var(--borderRadius-general-2x);
+  --input-field-borderRadius-default: var(--borderRadius-general-4x);
 }

--- a/src/styles/theme/light.css
+++ b/src/styles/theme/light.css
@@ -37,23 +37,26 @@
   --button-transparent-disabled-font-color: var(--palette-gray-4);
   --input-field-enabled-label-font-color: var(--palette-neutral-130-black);
   --input-field-enabled-assistive-font-color: var(--palette-neutral-130-black);
-  --input-field-enabled-font-color: var(--palette-neutral-70);
-  --input-field-hover-font-color: var(--palette-neutral-70);
-  --input-field-active-font-color: var(--palette-neutral-70);
-  --input-field-focus-font-color: var(--palette-neutral-130-black);
-  --input-field-valid-font-color: var(--palette-neutral-130-black);
-  --input-field-invalid-font-color: var(--palette-semantic-error-60B);
-  --input-field-disabled-font-color: var(--palette-neutral-60B);
-  --input-field-enabled-border-color: var(--palette-neutral-50);
-  --input-field-enabled-background-color: rgba(255, 255, 255, 0);
-  --input-field-hover-border-color: var(--palette-neutral-50);
-  --input-field-hover-background-color: rgba(
-    255,
-    255,
-    255,
-    0.05000000074505806
+  --input-field-enabled-font-color: var(--palette-gray-2);
+  --input-field-enabled-font-before-after: var(--palette-gray-3);
+  --input-field-enabled-placeholder: var(--palette-gray-3);
+  --input-field-hover-font-color: var(--palette-gray-2);
+  --input-field-hover-placeholder: var(--palette-gray-2);
+  --input-field-active-font-color: var(--palette-gray-2);
+  --input-field-focus-font-color-before-after: var(
+    --input-field-enabled-font-color
   );
-  --input-field-active-border-color: var(--palette-neutral-70);
+  --input-field-focus-font-color: var(--palette-neutral-130-black);
+  --input-field-valid-font-before-after: var(--palette-gray-3);
+  --input-field-valid-font-color: var(--palette-gray-2);
+  --input-field-invalid-font-color: var(--palette-semantic-error-60B);
+  --input-field-invalid-font-before-after: var(--palette-semantic-error-60B);
+  --input-field-disabled-font-color: var(--palette-gray-3);
+  --input-field-enabled-border-color: var(--input-regular-border);
+  --input-field-enabled-background-color: rgba(255, 255, 255, 0);
+  --input-field-hover-border-color: var(--palette-gray-2);
+  --input-field-hover-background-color: rgba(255, 255, 255, 0.05);
+  --input-field-active-border-color: var(--palette-gray-2);
   --input-field-active-background-color: rgba(255, 255, 255, 0);
   --input-field-focus-border-color: var(--palette-active-50);
   --input-field-focus-background-color: rgba(255, 255, 255, 0);
@@ -61,13 +64,8 @@
   --input-field-valid-background-color: rgba(255, 255, 255, 0);
   --input-field-invalid-border-color: var(--palette-semantic-error-60B);
   --input-field-invalid-background-color: rgba(255, 255, 255, 0);
-  --input-field-disabled-border-color: var(--palette-neutral-60B);
-  --input-field-disabled-background-color: rgba(
-    0.33216095762327313,
-    0.33216095762327313,
-    0.33216095762327313,
-    0.10000000149011612
-  );
+  --input-field-disabled-border-color: var(--input-regular-border);
+  --input-field-disabled-background-color: var(--palette-gray-4);
   --typography-h1-font-color: var(--palette-neutral-130-black);
   --typography-h2-font-color: var(--palette-neutral-130-black);
   --typography-h3-font-color: var(--palette-neutral-130-black);


### PR DESCRIPTION
## Bug fix for previous PR
Last time I didn't fully understand the logic of the UI kit variables and reassigned one variable (**borderRadius-general-2x**) in the _locationtips.css_ theme. Instead, I should have replaced the border-radius value with another variable in _webdesktop.css_ and other templates. In this commit, I've fixed that error and specified the correct variables in all templates.

## MInput Fitted to design
Variables for MInput, MLabel, MCaption, MFieldDescription components are set according to the design.
The design does not explicitly specify colors for hover, active, focus, valid, and disabled states, as well as their combinations, so I made them at my discretion. In any case, it will be easy to change the colors by replacing the variable in light.css.

![image](https://github.com/user-attachments/assets/34497b4f-254b-47e3-b3f8-d6336189e47d)
![image](https://github.com/user-attachments/assets/610b4e98-80cb-4ea7-b474-04fe80da0bf9)
![image](https://github.com/user-attachments/assets/6ebcdbcd-76db-4150-acf7-39b0a0a98ac3)
![image](https://github.com/user-attachments/assets/8968d480-7f40-421c-b02e-5d66fbbc92cb)
![image](https://github.com/user-attachments/assets/eff5d9dc-0c8b-44f9-8d80-d4925fca1761)