### PR TITLE
[UIKit] Round mode for MButton component

### DIFF
--- a/src/atoms/MButton/MButton.module.css
+++ b/src/atoms/MButton/MButton.module.css
@@ -17,8 +17,7 @@
 .after,
 .before,
 .buttonContent {
-  height: 24px;
-  font-family: var(--font-family);
+  font-family: var(--font-family, sans-serif);
   line-height: normal;
 }
 
@@ -43,8 +42,23 @@
   border-radius: var(--button-tertiary-borderRadius-default, 8px);
   color: var(--button-tertiary-enabled-font-color, #1e222a);
   background: var(--button-tertiary-enabled-background-color, #f4f5f7);
+  gap: var(--button-tertiary-medium-whiteSpace-gap, 4px);
   transition: outline 0.2s ease-in-out;
   outline: 1px solid var(--button-tertiary-border-default-color, #f4f5f7);
+}
+
+.tertiary span {
+  font-size: var(--font-size-l, 16px);
+}
+
+.round {
+  width: var(--button-round-size-default, 32px);
+  height: var(--button-round-size-default, 32px);
+  border-radius: 50%;
+}
+
+.round span {
+  overflow: hidden;
 }
 
 .outlined {
@@ -162,7 +176,6 @@
 }
 
 .tertiary .buttonContent {
-  font-size: var(--font-size-l, 16px);
   font-weight: 500;
 }
 

--- a/src/atoms/MButton/MButton.module.css
+++ b/src/atoms/MButton/MButton.module.css
@@ -38,23 +38,20 @@
 }
 
 .tertiary {
-  padding: var(--button-padding-tertiary, 6px);
   border-radius: var(--button-tertiary-borderRadius-default, 8px);
   color: var(--button-tertiary-enabled-font-color, #1e222a);
   background: var(--button-tertiary-enabled-background-color, #f4f5f7);
   gap: var(--button-tertiary-medium-whiteSpace-gap, 4px);
-  transition: outline 0.2s ease-in-out;
   outline: 1px solid var(--button-tertiary-border-default-color, #f4f5f7);
-}
-
-.tertiary span {
-  font-size: var(--font-size-l, 16px);
+  transition: outline 0.2s ease-in-out;
 }
 
 .round {
-  width: var(--button-round-size-default, 32px);
-  height: var(--button-round-size-default, 32px);
   border-radius: 50%;
+  color: var(--button-tertiary-enabled-font-color, #1e222a);
+  background: var(--button-round-enabled-background-color, #f4f5f7);
+  outline: 1px solid var(--button-round-border-default-color, #f4f5f7);
+  transition: outline 0.2s ease-in-out;
 }
 
 .round span {
@@ -103,6 +100,15 @@
   outline-color: var(--button-tertiary-border-disabled-color, #f4f5f7);
 }
 
+.round:disabled,
+.round:disabled:hover,
+.round:disabled:active {
+  color: var(--button-round-disabled-font-color, #747e97);
+  background: var(--button-round-disabled-background-color, #f4f5f7);
+  cursor: default;
+  outline-color: var(--button-round-border-disabled-color, #f4f5f7);
+}
+
 .outlined:disabled,
 .outlined:disabled:hover,
 .outlined:disabled:active {
@@ -135,6 +141,11 @@
   outline-color: var(--button-tertiary-border-hover-color, #babecb);
 }
 
+.round:hover {
+  background: var(--button-round-hover-background-color, #f4f5f7);
+  outline-color: var(--button-round-border-hover-color, #babecb);
+}
+
 .outlined:hover {
   border: 1px solid var(--button-outlined-hover-border-color, #babecb);
 }
@@ -158,6 +169,11 @@
   outline-color: var(--button-tertiary-border-active-color, #747e97);
 }
 
+.round:active {
+  background: var(--button-round-active-background-color, #f4f5f7);
+  outline-color: var(--button-round-border-active-color, #747e97);
+}
+
 .outlined:active {
   color: var(--button-outlined-active-font-color);
   border: 1px solid var(--button-outlined-active-border-color, #babecb);
@@ -179,6 +195,10 @@
   font-weight: 500;
 }
 
+.round .buttonContent {
+  font-weight: 500;
+}
+
 .outlined .buttonContent {
   font-weight: 500;
 }
@@ -187,20 +207,66 @@
   width: 100%;
 }
 
-.s {
+.primary.s,
+.secondary.s,
+.outlined.s,
+.transparent.s {
   padding: var(--button-padding-vertical-s, 6px)
     var(--button-padding-horizontal-s, 12px);
-  font-size: var(--font-size-s, 14px);
+  font-size: var(--button-font-size-small, 14px);
 }
 
-.m {
+.primary.m,
+.secondary.m,
+.outlined.m,
+.transparent.m {
   padding: var(--button-padding-vertical-m, 8px)
     var(--button-padding-horizontal-m, 16px);
-  font-size: var(--font-size-m, 14px);
+  font-size: var(--button-font-size-medium, 14px);
 }
 
-.l {
+.primary.l,
+.secondary.l,
+.outlined.l,
+.transparent.l {
   padding: var(--button-padding-vertical-l, 10px)
     var(--button-padding-horizontal-l, 16px);
-  font-size: var(--font-size-l, 16px);
+  font-size: var(--button-font-size-default, 16px);
+}
+
+.tertiary.s,
+.round.s {
+  padding: var(--button-padding-tertiary-s, 4px);
+  font-size: var(--button-font-size-medium, 14px);
+}
+
+.tertiary.m,
+.round.m {
+  padding: var(--button-padding-tertiary-m, 6px);
+  font-size: var(--button-font-size-default, 16px);
+}
+
+.tertiary.l,
+.round.l {
+  padding: var(--button-padding-tertiary-l, 8px);
+}
+
+.tertiary.l {
+  font-size: var(--button-font-size-xl, 20px);
+}
+
+.round.s {
+  width: var(--button-round-size-small, 24px);
+  height: var(--button-round-size-small, 24px);
+}
+
+.round.m {
+  width: var(--button-round-size-default, 32px);
+  height: var(--button-round-size-default, 32px);
+}
+
+.round.l {
+  width: var(--button-round-size-large, 48px);
+  height: var(--button-round-size-large, 48px);
+  font-size: var(--button-font-size-xl, 20px);
 }

--- a/src/atoms/MButton/MButton.stories.ts
+++ b/src/atoms/MButton/MButton.stories.ts
@@ -23,7 +23,14 @@ export const Basic: Story = {
   argTypes: {
     disabled: { control: { type: 'boolean' } },
     mode: {
-      options: ['primary', 'secondary', 'tertiary', 'outlined', 'transparent'],
+      options: [
+        'primary',
+        'secondary',
+        'tertiary',
+        'round',
+        'outlined',
+        'transparent',
+      ],
       control: { type: 'select' },
     },
     before: {

--- a/src/atoms/MButton/MButton.tsx
+++ b/src/atoms/MButton/MButton.tsx
@@ -11,7 +11,13 @@ type ButtonProps = DetailedHTMLProps<
   ButtonHTMLAttributes<HTMLButtonElement>,
   HTMLButtonElement
 > & {
-  mode?: 'primary' | 'secondary' | 'tertiary' | 'outlined' | 'transparent';
+  mode?:
+    | 'primary'
+    | 'secondary'
+    | 'tertiary'
+    | 'round'
+    | 'outlined'
+    | 'transparent';
   after?: ReactNode;
   before?: ReactNode;
   stretch?: boolean;
@@ -33,11 +39,12 @@ export const MButton = ({
       className={clsx(
         styles.button,
         className,
+        mode === 'round' ? [styles.tertiary, styles.round] : styles[mode],
         styles[mode],
         {
           [styles.stretch]: stretch,
         },
-        mode === 'tertiary' ? null : styles[size]
+        mode === 'tertiary' || mode === 'round' ? null : styles[size]
       )}
       {...restProps}
     >

--- a/src/atoms/MButton/MButton.tsx
+++ b/src/atoms/MButton/MButton.tsx
@@ -39,12 +39,11 @@ export const MButton = ({
       className={clsx(
         styles.button,
         className,
-        mode === 'round' ? [styles.tertiary, styles.round] : styles[mode],
         styles[mode],
         {
           [styles.stretch]: stretch,
         },
-        mode === 'tertiary' || mode === 'round' ? null : styles[size]
+        styles[size]
       )}
       {...restProps}
     >

--- a/src/styles/brand/locationtips.css
+++ b/src/styles/brand/locationtips.css
@@ -2,9 +2,10 @@
   /* typo */
   --font-family: Poppins, sans-serif;
   --font-family-secondary: Roboto, sans-serif;
-  --font-size-s: 0.875rem;
+  --font-size-s: 0.625rem;
   --font-size-m: 0.875rem;
   --font-size-l: 1rem;
+  --font-size-xl: 1.25rem;
 
   /* palette */
   /* primary */
@@ -101,7 +102,9 @@
   --button-padding-horizontal-s: 0.75rem;
   --button-padding-horizontal-m: 1rem;
   --button-padding-horizontal-l: 1rem;
-  --button-padding-tertiary: 0.375rem;
+  --button-padding-tertiary-s: 0.25rem;
+  --button-padding-tertiary-m: 0.375rem;
+  --button-padding-tertiary-l: 0.5rem;
 
   /* not used */
   --palette-tertiary-10: rgba(255, 250, 240, 1);

--- a/src/styles/platform/android.css
+++ b/src/styles/platform/android.css
@@ -1,5 +1,9 @@
 :root[data-platform='android'] {
   --layout-screen-padding-horizontal: var(--whiteSpace-general-2x);
+  --button-font-size-default: var(--font-size-l);
+  --button-font-size-medium: var(--font-size-m);
+  --button-font-size-small: var(--font-size-s);
+  --button-font-size-xl: var(--font-size-xl);
   --button-primary-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );
@@ -21,6 +25,8 @@
   --button-tertiary-borderRadius-default: var(--borderRadius-general-2x);
   --button-tertiary-medium-whiteSpace-gap: var(--whiteSpace-general-_5x);
   --button-round-size-default: var(--size-general-4x);
+  --button-round-size-small: var(--size-general-3x);
+  --button-round-size-large: var(--size-general-6x);
   --button-outlined-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );

--- a/src/styles/platform/android.css
+++ b/src/styles/platform/android.css
@@ -19,6 +19,8 @@
     --borderRadius-general-4x
   );
   --button-tertiary-borderRadius-default: var(--borderRadius-general-2x);
+  --button-tertiary-medium-whiteSpace-gap: var(--whiteSpace-general-_5x);
+  --button-round-size-default: var(--size-general-4x);
   --button-outlined-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );

--- a/src/styles/platform/ios.css
+++ b/src/styles/platform/ios.css
@@ -1,5 +1,9 @@
 :root[data-platform='i-os'] {
   --layout-screen-padding-horizontal: var(--whiteSpace-general-2x);
+  --button-font-size-default: var(--font-size-l);
+  --button-font-size-medium: var(--font-size-m);
+  --button-font-size-small: var(--font-size-s);
+  --button-font-size-xl: var(--font-size-xl);
   --button-primary-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );
@@ -21,6 +25,8 @@
   --button-tertiary-borderRadius-default: var(--borderRadius-general-2x);
   --button-tertiary-medium-whiteSpace-gap: var(--whiteSpace-general-_5x);
   --button-round-size-default: var(--size-general-4x);
+  --button-round-size-small: var(--size-general-3x);
+  --button-round-size-large: var(--size-general-6x);
   --button-outlined-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );

--- a/src/styles/platform/ios.css
+++ b/src/styles/platform/ios.css
@@ -19,6 +19,8 @@
     --borderRadius-general-4x
   );
   --button-tertiary-borderRadius-default: var(--borderRadius-general-2x);
+  --button-tertiary-medium-whiteSpace-gap: var(--whiteSpace-general-_5x);
+  --button-round-size-default: var(--size-general-4x);
   --button-outlined-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );

--- a/src/styles/platform/webdesktop.css
+++ b/src/styles/platform/webdesktop.css
@@ -1,5 +1,9 @@
 :root[data-platform='web-desktop'] {
   --layout-screen-padding-horizontal: var(--whiteSpace-general-6x);
+  --button-font-size-default: var(--font-size-l);
+  --button-font-size-medium: var(--font-size-m);
+  --button-font-size-small: var(--font-size-s);
+  --button-font-size-xl: var(--font-size-xl);
   --button-primary-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );
@@ -21,6 +25,8 @@
   --button-tertiary-borderRadius-default: var(--borderRadius-general-2x);
   --button-tertiary-medium-whiteSpace-gap: var(--whiteSpace-general-_5x);
   --button-round-size-default: var(--size-general-4x);
+  --button-round-size-small: var(--size-general-3x);
+  --button-round-size-large: var(--size-general-6x);
   --button-outlined-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );

--- a/src/styles/platform/webdesktop.css
+++ b/src/styles/platform/webdesktop.css
@@ -19,6 +19,8 @@
     --borderRadius-general-4x
   );
   --button-tertiary-borderRadius-default: var(--borderRadius-general-2x);
+  --button-tertiary-medium-whiteSpace-gap: var(--whiteSpace-general-_5x);
+  --button-round-size-default: var(--size-general-4x);
   --button-outlined-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );

--- a/src/styles/platform/webmobile.css
+++ b/src/styles/platform/webmobile.css
@@ -19,6 +19,8 @@
     --borderRadius-general-4x
   );
   --button-tertiary-borderRadius-default: var(--borderRadius-general-2x);
+  --button-tertiary-medium-whiteSpace-gap: var(--whiteSpace-general-_5x);
+  --button-round-size-default: var(--size-general-4x);
   --button-outlined-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );

--- a/src/styles/platform/webmobile.css
+++ b/src/styles/platform/webmobile.css
@@ -1,5 +1,9 @@
 :root[data-platform='web-mobile'] {
   --layout-screen-padding-horizontal: var(--whiteSpace-general-2x);
+  --button-font-size-default: var(--font-size-l);
+  --button-font-size-medium: var(--font-size-m);
+  --button-font-size-small: var(--font-size-s);
+  --button-font-size-xl: var(--font-size-xl);
   --button-primary-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );
@@ -21,6 +25,8 @@
   --button-tertiary-borderRadius-default: var(--borderRadius-general-2x);
   --button-tertiary-medium-whiteSpace-gap: var(--whiteSpace-general-_5x);
   --button-round-size-default: var(--size-general-4x);
+  --button-round-size-small: var(--size-general-3x);
+  --button-round-size-large: var(--size-general-6x);
   --button-outlined-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );

--- a/src/styles/platform/webtablet.css
+++ b/src/styles/platform/webtablet.css
@@ -1,5 +1,9 @@
 :root[data-platform='web-tablet'] {
   --layout-screen-padding-horizontal: var(--whiteSpace-general-4x);
+  --button-font-size-default: var(--font-size-l);
+  --button-font-size-medium: var(--font-size-m);
+  --button-font-size-small: var(--font-size-s);
+  --button-font-size-xl: var(--font-size-xl);
   --button-primary-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );
@@ -21,6 +25,8 @@
   --button-tertiary-borderRadius-default: var(--borderRadius-general-2x);
   --button-tertiary-medium-whiteSpace-gap: var(--whiteSpace-general-_5x);
   --button-round-size-default: var(--size-general-4x);
+  --button-round-size-small: var(--size-general-3x);
+  --button-round-size-large: var(--size-general-6x);
   --button-outlined-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );

--- a/src/styles/platform/webtablet.css
+++ b/src/styles/platform/webtablet.css
@@ -19,6 +19,8 @@
     --borderRadius-general-4x
   );
   --button-tertiary-borderRadius-default: var(--borderRadius-general-2x);
+  --button-tertiary-medium-whiteSpace-gap: var(--whiteSpace-general-_5x);
+  --button-round-size-default: var(--size-general-4x);
   --button-outlined-medium-whiteSpace-padding-horizontal: var(
     --whiteSpace-general-2x
   );

--- a/src/styles/theme/light.css
+++ b/src/styles/theme/light.css
@@ -35,6 +35,19 @@
   --button-tertiary-border-hover-color: var(--palette-gray-3);
   --button-tertiary-border-focus-color: var(--palette-gray-3);
   --button-tertiary-border-active-color: var(--palette-gray-2);
+  /* button round */
+  --button-round-enabled-background-color: var(--palette-gray-4);
+  --button-round-disabled-background-color: var(--palette-gray-4);
+  --button-round-hover-background-color: var(--palette-gray-4);
+  --button-round-active-background-color: var(--palette-gray-4);
+  --button-round-enabled-font-color: var(--palette-gray-1);
+  --button-round-disabled-font-color: var(--palette-gray-2);
+  --button-round-hover-font-color: var(--palette-gray-1);
+  --button-round-border-default-color: var(--palette-gray-4);
+  --button-round-border-disabled-color: var(--palette-gray-4);
+  --button-round-border-hover-color: var(--palette-gray-3);
+  --button-round-border-focus-color: var(--palette-gray-3);
+  --button-round-border-active-color: var(--palette-gray-2);
   /* button outlined */
   --button-outlined-enabled-background-color: rgba(255, 255, 255, 0);
   --button-outlined-enabled-border-color: var(--palette-gray-2);


### PR DESCRIPTION
Added 'round' mode for MButton component. When mode is set 'round', tertiary styles are applied automatically.
![image](https://github.com/user-attachments/assets/63c98e91-9a00-4351-9bee-ab94bcadaf15)
![image](https://github.com/user-attachments/assets/87a71e56-2d17-45f0-9f65-fe4039078ebe)
